### PR TITLE
[Fixed] Percent symbol commentChar

### DIFF
--- a/commit-message.YAML-tmLanguage
+++ b/commit-message.YAML-tmLanguage
@@ -7,11 +7,11 @@ uuid: BFE83C06-8508-44BE-A975-95A57BF619A7
 patterns:
 - comment: "Comments don't count when looking for the 'first line' of a commit."
   name: comment.line.number-sign.git-commit
-  match: ^\s*(#).*$\n?
+  match: ^\s*([#|%]).*$\n?
   captures:
     '1': {name: punctuation.definition.comment.git-commit}
 
-- include: '#diff'
+- include: '[#|%]diff'
 
 - comment: Capture the whole commit message to test the length of the first line.
     NB the end pattern is just something to be never matched so the capture continues
@@ -26,38 +26,38 @@ patterns:
     '2': { name: 'entity' }
     '3': { name: invalid.deprecated.line-too-long.git-commit }
     '4': { name: invalid.illegal.line-too-long.git-commit }
-  end: (?=^# \-+ \>8 \-+$)|(?=xxxxxx)123457
+  end: (?=^[#|%] \-+ \>8 \-+$)|(?=xxxxxx)123457
   patterns:
   - comment: capture the second line
     begin: ^(()|(.*\s*))$
     beginCaptures:
       '3': { name: invalid.illegal.line-too-long.git-commit }
-    end: (?=^# \-+ \>8 \-+$)|(?=xxxxxx)123458
+    end: (?=^[#|%] \-+ \>8 \-+$)|(?=xxxxxx)123458
     patterns:
     - name: commit-text.git-commit
-      match: ^(?:(?!#))((.{0,72})(.*))$\n?
+      match: ^(?:(?![#|%]))((.{0,72})(.*))$\n?
       captures:
         '3': { name: invalid.illegal.line-too-long.git-commit }
         # '4': { name: invalid.illegal.line-too-long.git-commit }
     - name: comment.line.number-sign.git-commit
-      match: (^#)\sYour branch is up-to-date with '(.*)'.
+      match: (^[#|%])\sYour branch is up-to-date with '(.*)'.
       captures:
         '2': { name: constant.branch-name }
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s(On branch\s)(.*)$\n?
+      match: (^[#|%])\s(On branch\s)(.*)$\n?
       captures:
         '3': { name: constant.branch-name }
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s(.*:)$\n?
+      match: (^[#|%])\s(.*:)$\n?
       captures:
         '2': {name: punctuation.definition.comment.git-commit, name: storage}
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s*(modified:.*)$\n?
+      match: (^[#|%])\s*(modified:.*)$\n?
       captures:
         '1': {name: punctuation.definition.comment.git-commit}
         '2': {name: markup.changed.git-commit}
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s*(renamed:)\s*(.*)\s*(->)\s*(.*)$\n?
+      match: (^[#|%])\s*(renamed:)\s*(.*)\s*(->)\s*(.*)$\n?
       captures:
         '1': {name: punctuation.definition.comment.git-commit}
         '2': {name: markup.changed.git-commit}
@@ -65,20 +65,20 @@ patterns:
         '4': {name: markup.changed.git-commit}
         '5': {name: markup.inserted.git-commit}
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s*(new file:.*)$\n?
+      match: (^[#|%])\s*(new file:.*)$\n?
       captures:
         '1': {name: punctuation.definition.comment.git-commit}
         '2': {name: markup.inserted.git-commit}
     - name: comment.line.number-sign.git-commit
-      match: (^#)\s*(deleted:.*)$\n?
+      match: (^[#|%])\s*(deleted:.*)$\n?
       captures:
         '1': {name: punctuation.definition.comment.git-commit}
         '2': {name: markup.deleted.git-commit}
     - name: comment.line.number-sign.git-commit
-      match: ^\s*(#).*$\n?
+      match: ^\s*([#|%]).*$\n?
       captures:
         '1': {name: punctuation.definition.comment.git-commit}
-    - include: '#diff'
+    - include: '[#|%]diff'
 
 repository:
   diff:

--- a/commit-message.tmLanguage
+++ b/commit-message.tmLanguage
@@ -26,13 +26,13 @@
 			<key>comment</key>
 			<string>Comments don't count when looking for the 'first line' of a commit.</string>
 			<key>match</key>
-			<string>^\s*(#).*$\n?</string>
+			<string>^\s*([#|%]).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.number-sign.git-commit</string>
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#diff</string>
+			<string>[#|%]diff</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -58,7 +58,7 @@
 			<key>comment</key>
 			<string>Capture the whole commit message to test the length of the first line. NB the end pattern is just something to be never matched so the capture continues until the end of the file.</string>
 			<key>end</key>
-			<string>(?=^# \-+ \&gt;8 \-+$)|(?=xxxxxx)123457</string>
+			<string>(?=^[#|%] \-+ \&gt;8 \-+$)|(?=xxxxxx)123457</string>
 			<key>name</key>
 			<string>first-line.git-commit</string>
 			<key>patterns</key>
@@ -77,7 +77,7 @@
 					<key>comment</key>
 					<string>capture the second line</string>
 					<key>end</key>
-					<string>(?=^# \-+ \&gt;8 \-+$)|(?=xxxxxx)123458</string>
+					<string>(?=^[#|%] \-+ \&gt;8 \-+$)|(?=xxxxxx)123458</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -90,7 +90,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>^(?:(?!#))((.{0,72})(.*))$\n?</string>
+							<string>^(?:(?![#|%]))((.{0,72})(.*))$\n?</string>
 							<key>name</key>
 							<string>commit-text.git-commit</string>
 						</dict>
@@ -104,7 +104,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\sYour branch is up-to-date with '(.*)'.</string>
+							<string>(^[#|%])\sYour branch is up-to-date with '(.*)'.</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -118,7 +118,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s(On branch\s)(.*)$\n?</string>
+							<string>(^[#|%])\s(On branch\s)(.*)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -132,7 +132,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s(.*:)$\n?</string>
+							<string>(^[#|%])\s(.*:)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -151,7 +151,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s*(modified:.*)$\n?</string>
+							<string>(^[#|%])\s*(modified:.*)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -185,7 +185,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s*(renamed:)\s*(.*)\s*(-&gt;)\s*(.*)$\n?</string>
+							<string>(^[#|%])\s*(renamed:)\s*(.*)\s*(-&gt;)\s*(.*)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -204,7 +204,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s*(new file:.*)$\n?</string>
+							<string>(^[#|%])\s*(new file:.*)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -223,7 +223,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(^#)\s*(deleted:.*)$\n?</string>
+							<string>(^[#|%])\s*(deleted:.*)$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
@@ -237,13 +237,13 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>^\s*(#).*$\n?</string>
+							<string>^\s*([#|%]).*$\n?</string>
 							<key>name</key>
 							<string>comment.line.number-sign.git-commit</string>
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#diff</string>
+							<string>[#|%]diff</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
### 1. Behavior before pull request

Commit message, if I use `%` symbol for commentChar:

![Before](http://i.imgur.com/IR0mxf5.png)

### 2. Behavior after pull request

![After](http://i.imgur.com/D4sSTVH.png)

Default value `#` also works:

![Default](http://i.imgur.com/IcTadjP.png)

### 3. Argumentation

I create pull requests (include this pull request) use [**hub**](https://hub.github.com/hub.1.html) utility. By default, `#` symbol rendering as comment. [**Example**](https://github.com/LightAlf/FirstRepo/pull/13):

```
Тут описание pull request.

# Requesting a pull to LightAlf:master from Kristinita:SashaGoddess
# 
# Write a message for this pull request. The first block
# of text is the title and the rest is the description.
# 
# Changes:
# 
# 6739ad9 (Kristinita, 12 days ago)
# Мы никто без Саши
# 
# c5f94bf (Kristinita, 12 days ago)
# Мы никто без Саши
# 
# 4bb3c16 (Kristinita, 12 days ago)
# Мы никто без Саши
# 
```

![Comment](http://i.imgur.com/mFCCaYY.png)

[**As say @mislav**](https://github.com/github/hub/issues/1247#issuecomment-245582549) — GitHub developer — is known issue. It fixed, if user print this command in a terminal:

    git config --global core.commentChar %

Now I use `%` symbol for commentChar → my pull request via hub don't have formatting errors.

### 4. Alternative

If you don't want to accept this pull request, it would be nice, if you add option in settings, for example:

    "comment_char": "%"

If user use `%` commentChar, user will see syntax highlight in commit messages.

Thanks.